### PR TITLE
CLASSES-2313 Remove the reset button from the "Overview" tool for the desktop view

### DIFF
--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -731,6 +731,14 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 				// this is here to allow the tool reorder to work
 				m.put("_sitePage", p);
 				l.add(m);
+
+				// NYU conditionally hide the breadcrumb on Overview / Home pages
+				// We'll consider one of these pages is generally a templated page
+				// containing more than one tool.
+				if (current && pTools.size() > 1) {
+					theMap.put("hideBreadcrumbOnDesktop", Boolean.valueOf(true));
+				}
+
 				continue;
 			}
 

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageWithNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageWithNav.vm
@@ -16,7 +16,11 @@
     #end ## END of IF ( $sitePages.pageNavToolsCount > 1 || ! $sitePages.pageMaxIfSingle )
 
     <div class="Mrphs-pagebody">
+        #if ( $sitePages.hideBreadcrumbOnDesktop )
+        <header class="nyu-hide-breadcrumb-on-desktop">
+        #else
         <header>
+        #end
             #parse("/vm/morpheus/snippets/siteStatus-snippet.vm")
 
             #parse("/vm/morpheus/includeBreadcrumb.vm")

--- a/reference/library/src/morpheus-master/sass/nyu/_tool.scss
+++ b/reference/library/src/morpheus-master/sass/nyu/_tool.scss
@@ -171,6 +171,26 @@ span.cke_bottom .cke_resizer.cke_resizer_ltr {
 //  Changes to Overview (synoptic tools)
 // -------------------------------------------------------------------------------------------------------------------
 
+@media #{$nonPhone} {
+
+  .nyu-hide-breadcrumb-on-desktop {
+    .#{$namespace}siteHierarchy {
+      display: none;
+    }
+  }
+
+  #content {
+    padding-top: 10px;
+  }
+
+  #jsr-edit {
+    position: absolute;
+    right: 0;
+    top: -10px;
+    min-width: 64px;
+  }
+}
+
 .#{$namespace}toolBody--sakai-iframe-site {
   border-bottom: none !important;
 }


### PR DESCRIPTION
Hey @marktriggs, I've had a go at this one, using a variable set in the portal and a CSS class to conditionally hide the breadcrumb header for desktop viewports.

I guess the trickiness is under what conditions we set `hideBreadcrumbOnDesktop` to be true. I've guessed that we'd apply this to any page that has more than one tool... but unsure if this will break other things?
