### PR TITLE
CLASSES-2605 add new lessons subpage menu to the tool menu for any lesson tools with subpages

### DIFF
--- a/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
+++ b/lessonbuilder/tool/src/java/org/sakaiproject/lessonbuildertool/tool/beans/SimplePageBean.java
@@ -2390,6 +2390,22 @@ public class SimplePageBean {
 			entry.title = title;
 			path = new ArrayList<PathEntry>();
 			path.add(entry);
+		} else if (op.equals("clear_and_push")) {
+			// clear path for top level subpage
+			path = new ArrayList<PathEntry>();
+			// add an entry for the parent page
+			SimplePage parentPage = getPage(currentPage.getParent());
+			PathEntry parentEntry = new PathEntry();
+			parentEntry.pageId = parentPage.getPageId();
+			parentEntry.pageItemId = -1L;
+			parentEntry.title = parentPage.getTitle();
+			path.add(parentEntry);
+			// add the subpage
+			PathEntry entry = new PathEntry();
+			entry.pageId = pageId;
+			entry.pageItemId = pageItemId;
+			entry.title = title;
+			path.add(entry);  // put it on the end
 	    } else if (path.get(path.size()-1).pageId.equals(pageId)) {
 	    	// nothing. we're already there. this is to prevent 
 	    	// oddities if we refresh the page

--- a/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
+++ b/portal/portal-impl/impl/src/java/org/sakaiproject/portal/charon/site/PortalSiteHelperImpl.java
@@ -82,7 +82,6 @@ import org.sakaiproject.portal.util.ToolUtils;
 import org.sakaiproject.portal.charon.PortalStringUtil;
 import org.sakaiproject.util.FormattedText;
 
-// FIXME: move elsewhere?
 import org.sakaiproject.db.cover.SqlService;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -881,7 +880,6 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 		return theMap;
 	}
 
-	// FIXME: move elsewhere?
 	private class LessonsTreeView {
 
 		public String lessonsPagesJSON(List pages) {
@@ -940,7 +938,8 @@ public class PortalSiteHelperImpl implements PortalSiteHelper
 					}
 				}
 			} catch (SQLException e) {
-				// TODO: log diagnostic
+                            log.error("Failed to get lessons tree: " + e.getMessage());
+                            e.printStackTrace();
 			}
 
 			return result;

--- a/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageNav.vm
+++ b/portal/portal-render-engine-impl/pack/src/webapp/vm/morpheus/includePageNav.vm
@@ -213,6 +213,11 @@
 
     #end ## END of IF ( $subSites )
 
+    <script src="/library/js/lessons-subnav.js$!{portalCDNQuery}"></script>
+    <script>
+        new LessonsSubPageNavigation($sitePages.additionalLessonsPages, "$sitePages.currentLessonsPage")
+    </script>
+
 </div>
 
 <!-- END VM includePageNav.vm -->

--- a/reference/library/src/morpheus-master/sass/nyu/_portal.scss
+++ b/reference/library/src/morpheus-master/sass/nyu/_portal.scss
@@ -1280,3 +1280,99 @@ body.#{$namespace}toolMenu-collapsed ul#subSites ul li a {
     }
   }
 }
+
+// -------------------------------------------------------------------------------------------------------------------
+//  Lessons-Tool Subpage Menu
+// -------------------------------------------------------------------------------------------------------------------
+body {
+  #toolMenu {
+    li.has-lessons-sub-pages {
+      &.is-parent-of-current.expanded {
+        a {
+          border-left: $nyu-tool-nav-item-border-left !important;
+        }
+      }
+
+      > a {
+        .#{$namespace}toolsNav__menuitem--icon {
+          &:before {
+            content: '\f054';
+          }
+        }
+      }
+
+      &.expanded {
+        > a {
+          .#{$namespace}toolsNav__menuitem--icon {
+            &:before {
+              content: '\f078';
+            }
+          }
+        }
+      }
+
+      ul.lessons-sub-page-menu {
+        display: none;
+  
+        li {
+          border-bottom: none;
+          min-height: 30px;
+
+          a {
+            text-align: left;
+            padding: 0.5em 0 0.5em 40px;
+            text-size: 12px !important;
+            min-height: 30px;
+            border-left: $nyu-tool-nav-item-border-left !important;
+
+            &:hover {
+              border-left: $nyu-tool-nav-item-hover-border-left !important;
+            }
+          }
+
+          &.is-current {
+            a {
+              border-left: $nyu-tool-nav-item-selected-border-left !important;
+            }
+          }
+        }
+      }
+  
+      &.expanded {
+        ul.lessons-sub-page-menu {
+          display: block;
+        }
+      }
+
+      position: relative;
+
+      .lessons-goto-top-page {
+        display: none;
+        position: absolute;
+        z-index: 2;
+        right: 0;
+        top: 0;
+        width: 30px;
+        line-height: 30px;
+        border: none !important;
+        background: none !important;
+
+        &:hover {
+          border: none !important;
+          background: none !important;
+        }
+
+        &:before {
+          font-family: 'FontAwesome';
+          content: '\f0a9';
+        }
+      }
+
+      &:hover {
+        .lessons-goto-top-page {
+          display: block;
+        }
+      }
+    }
+  }
+}

--- a/reference/library/src/webapp/js/lessons-subnav.js
+++ b/reference/library/src/webapp/js/lessons-subnav.js
@@ -1,0 +1,89 @@
+(function() {
+    function LessonsSubPageNavigation(data, currentPageId) {
+        this.data = data;
+        this.currentPageId = currentPageId;
+        this.setup();
+    };
+
+    LessonsSubPageNavigation.prototype.setup = function() {
+        var self = this;
+
+        for (var page_id in self.data) {
+            if (self.data.hasOwnProperty(page_id)) {
+                var sub_pages = self.data[page_id];
+                self.render_subnav_for_page(page_id, sub_pages);
+            }
+        }
+    };
+
+    LessonsSubPageNavigation.prototype.render_subnav_for_page = function(page_id, sub_pages) {
+        var self = this;
+
+        var $menu = document.querySelector('#toolMenu a[href$="/tool/'+page_id+'"], #toolMenu [href$="/tool-reset/'+page_id+'"]');
+        var $li = $menu.parentElement;
+
+        var $submenu = document.createElement('ul');
+        $submenu.classList.add('lessons-sub-page-menu');
+
+        sub_pages.forEach(function(sub_page) {
+            var $submenu_item = document.createElement('li');
+            var $submenu_action = document.createElement('a');
+
+            $submenu_action.href = self.build_sub_page_url_for(sub_page);
+            $submenu_action.innerText = sub_page.name;
+            $submenu_item.appendChild($submenu_action);
+
+            $submenu.appendChild($submenu_item);
+
+            if (sub_page.sendingPage === self.currentPageId) {
+                $li.classList.add('is-parent-of-current');
+                $submenu_item.classList.add('is-current');
+            }
+        });
+
+        self.setup_parent_menu($li, $menu);
+        $li.appendChild($submenu);
+    };
+
+
+    LessonsSubPageNavigation.prototype.setup_parent_menu = function($li, $menu) {
+        $li.classList.add('has-lessons-sub-pages');
+        var $goto = document.createElement('a');
+        $goto.href = $menu.href;
+        $goto.classList.add('lessons-goto-top-page');
+        $menu.href = 'javascript:void(0);';
+
+        $menu.addEventListener('click', function(event) {
+            event.preventDefault();
+            if ($li.classList.contains('expanded')) {
+                $li.classList.remove('expanded');
+            } else {
+                var $ul = $li.parentElement;
+                $li.querySelectorAll('li.expanded').forEach(function(el) {
+                    el.classList.remove('expanded');
+                });
+                $li.classList.add('expanded');
+            }
+        });
+
+        if ($li.classList.contains('is-current')) {
+            $li.classList.add('expanded');
+        }
+
+        $li.appendChild($goto);
+    };
+
+
+    LessonsSubPageNavigation.prototype.build_sub_page_url_for = function(sub_page) {
+        var url = '/portal/site/' + sub_page.siteId;
+        url += '/tool/' + sub_page.toolId;
+        url += '/ShowPage?sendingPage='+sub_page.sendingPage;
+        url += '&itemId='+sub_page.itemId;
+        url += '&path=clear_and_push';
+        url += '&title=' + sub_page.name;
+        url += '&newTopLevel=false';
+        return url;
+    };
+
+    window.LessonsSubPageNavigation = LessonsSubPageNavigation;
+})();


### PR DESCRIPTION
Does things:

 - apply Mark's JSON LessonsTreeView changes
 - first pass at adding the new lessons subpage menu to the portal and morpheus bits
 - add clear_and_push path-adjust parameter so we can fudge the breadcrumb from our new submenu
 - refactor the javascript to use native over jQuery so we can run the menu code before jQuery is loaded in the page