### PR TITLE
CLASSES-3060 fix exception for TAs when grading in assignment tool

### DIFF
--- a/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sections/AuthzSectionsImpl.java
+++ b/edu-services/gradebook-service/impl/src/java/org/sakaiproject/tool/gradebook/facades/sections/AuthzSectionsImpl.java
@@ -215,6 +215,9 @@ public class AuthzSectionsImpl implements Authz {
 	
 			return false;
 			
+		// CLASSES-3060 if user role in site has been set as TA, then assume they should be able to grade
+		} else if (isUserAbleToGrade(gradebookUid, userUid)) {
+			return true;
 		} else {
 			// use OOTB permissions based upon TA section membership
 			for (Iterator iter = sectionIds.iterator(); iter.hasNext(); ) {


### PR DESCRIPTION
Hi @marktriggs,

Just hoping you can double check my logic on this one.  

This for https://jira.nyu.edu/jira/browse/CLASSES-3060 and takes the suggested patch from Longsight and a slight tinkering.  Namely, I've moved the check to happen after we hit the gradebookPermissionService, which should allow any permissions set in the Gradebook tool to take precedence.

Can confirm it works, but just want to bounce it off another head.  I think Instructors will be unaffected as they exit out of the `isUserAbleToGradeOrViewItemForStudent` method when `isUserAbleToGradeAll` is called.